### PR TITLE
PR for %imc_parse PAPI placeholder

### DIFF
--- a/core/src/main/java/to/itsme/itsmyconfig/hook/PAPIHook.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/hook/PAPIHook.java
@@ -188,7 +188,7 @@ public final class PAPIHook extends PlaceholderExpansion {
             
             return switch (format) {
                 case "legacy", "l" -> BukkitComponentSerializer.legacy().serialize(component);
-                case "console", "c" -> BukkitComponentSerializer.legacySection().serialize(component);
+                case "console", "c" -> BukkitComponentSerializer.legacy().serialize(component);
                 case "mini", "m" -> IMCSerializer.toMiniMessage(component);
                 default -> IMCSerializer.toMiniMessage(component);
             };

--- a/core/src/main/java/to/itsme/itsmyconfig/hook/PAPIHook.java
+++ b/core/src/main/java/to/itsme/itsmyconfig/hook/PAPIHook.java
@@ -167,7 +167,7 @@ public final class PAPIHook extends PlaceholderExpansion {
         String content = contentBuilder.toString();
         
         // Check if there's a format specification at the end (e.g., _legacy, _mini, _console)
-        String format = "mini"; // default format
+        String format = "legacy"; // default format
         String[] formatParts = content.split("_");
         if (formatParts.length > 0) {
             String lastPart = formatParts[formatParts.length - 1].toLowerCase();


### PR DESCRIPTION
This PR allows you to use ItsMyConfig in Holograms:
<img width="542" height="289" alt="image" src="https://github.com/user-attachments/assets/40fa88d7-30ab-47d1-88a5-f7aeb7bcfda7" />
Example in above hologram:
```
%imc_parse_<p:server-name>%
%imc_parse_<p:prefix>%
```


This allows for custom creations such as the following:

<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/b1aa4cc6-d90b-48d1-85e9-ade93020d7e1" />
<img width="1920" height="1009" alt="image" src="https://github.com/user-attachments/assets/94a0ee53-e249-4b0f-815b-26917089d29a" />
